### PR TITLE
Return empty NotFound when Details/Failure is nil

### DIFF
--- a/serviceerror/convert.go
+++ b/serviceerror/convert.go
@@ -91,11 +91,13 @@ func FromStatus(st *status.Status) error {
 	f := extractFailure(st)
 	switch st.Code() {
 	case codes.NotFound:
-		if f != nil {
-			return newNotFound(st, f.(*failure.NotFound))
+		if f == nil{
+			return newNotFound(st, nil)
 		}
-		
-		return newNotFound(st, &failure.NotFound{})
+		switch f := f.(type) {
+		case *failure.NotFound:
+			return newNotFound(st, f)
+		}
 	case codes.InvalidArgument:
 		if f == nil {
 			return newInvalidArgument(st)

--- a/serviceerror/convert.go
+++ b/serviceerror/convert.go
@@ -91,7 +91,11 @@ func FromStatus(st *status.Status) error {
 	f := extractFailure(st)
 	switch st.Code() {
 	case codes.NotFound:
-		return newNotFound(st, f.(*failure.NotFound))
+		if f != nil {
+			return newNotFound(st, f.(*failure.NotFound))
+		}
+		
+		return newNotFound(st, &failure.NotFound{})
 	case codes.InvalidArgument:
 		if f == nil {
 			return newInvalidArgument(st)


### PR DESCRIPTION
Fix for when details are not specified - See this test in SDK https://github.com/temporalio/temporal-go-sdk/blob/v0.22.0/internal/grpc_dialer_test.go#L39